### PR TITLE
Fixed the 404 h1 placement when the main menu is really short

### DIFF
--- a/404.php
+++ b/404.php
@@ -29,7 +29,7 @@ if ( is_array( get_option( 'wordpress_asu_theme_options' ) ) ) {
 get_header();
 ?>
 
-<div id="main-wrapper" class="clearfix">
+<div id="main-wrapper" class="clearfix four-oh-four-error-page">
   <div id="main" class="clearfix">
     <div class="column">
       <div class="region region-content">

--- a/style.css
+++ b/style.css
@@ -22,6 +22,11 @@ Licensed under MIT.
   margin: 5px 20px 20px 0;
 }
 
+/* The 404 page h1 wont clear the main nav on its own */
+.four-oh-four-error-page .fdt-home-container {
+  clear:both;
+}
+
 .screen-reader-text {
   height: 1px;
   left: -10000px;


### PR DESCRIPTION
This is a rare case, but it has happened