### PR TITLE
changing use of empty to support php 5.4 and older

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ services:
   - mysql
 
 php:
+  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/single.php
+++ b/single.php
@@ -27,7 +27,7 @@ $custom_fields = get_post_custom();
               // Default widths for having a sidebar
               $content_class = 'col-sm-8';
               $sidebar_class = 'col-sm-4 hidden-xs';
-            if ( trim( $sidebar_content ) == false ) {
+            if ( false == trim( $sidebar_content ) ) {
               // if the sidebar has no content then the page should take it all up
               $content_class = 'col-sm-12';
               $sidebar_class = 'hidden-xs';

--- a/single.php
+++ b/single.php
@@ -27,7 +27,7 @@ $custom_fields = get_post_custom();
               // Default widths for having a sidebar
               $content_class = 'col-sm-8';
               $sidebar_class = 'col-sm-4 hidden-xs';
-            if ( empty( trim( $sidebar_content ) ) ) {
+            if ( trim( $sidebar_content ) == false ) {
               // if the sidebar has no content then the page should take it all up
               $content_class = 'col-sm-12';
               $sidebar_class = 'hidden-xs';


### PR DESCRIPTION
in php 5.4 empty only takes variables, so we should fall back on using trim and depending on "" being falsey. Addresses #260