### PR TITLE
Updated Archive template to auto hide sidebar region

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -24,7 +24,22 @@ get_header(); ?>
       <main id="main" class="site-main space-top-md" role="main">
         <div class="container">
           <div class="row">
-            <div class="col-sm-8">
+            <?php
+              ob_start();
+                get_sidebar();
+                $sidebar_content = ob_get_contents();
+              ob_end_clean();
+
+              // Default widths for having a sidebar
+              $content_class = 'col-sm-8';
+              $sidebar_class = 'col-sm-4 hidden-xs';
+            if ( false == trim( $sidebar_content ) ) {
+              // if the sidebar has no content then the page should take it all up
+              $content_class = 'col-sm-12';
+              $sidebar_class = 'hidden-xs';
+            }
+            ?>
+            <div class="<?php echo esc_attr( $content_class ); ?>">
               <?php
               while ( have_posts() ) {
                 the_post();
@@ -37,9 +52,9 @@ get_header(); ?>
               } // end of the loop.
               ?>
             </div>
-            <div class="col-sm-4 hidden-xs">
+            <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">
-                <?php get_sidebar(); ?>
+                <?php echo wp_kses( $sidebar_content, wp_kses_allowed_html( 'post' ) ); ?>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Similar to the previous update to the Category template (in PR #275), included logic from single.php
to disable widget region when no sidebar has been configured, allowing post content to be
formatted full-width.