### PR TITLE
shortcode defaults overriding the page custom fields for hero type

### DIFF
--- a/inc/shortcodes/page-features-shortcode.php
+++ b/inc/shortcodes/page-features-shortcode.php
@@ -33,7 +33,7 @@ if ( ! function_exists( 'page_feature' ) ) :
         'video' => null,
         'description' => null,
         'color' => false,
-        'type'  => 'standard',
+        'type'  => null, // this is not the default
         'hide_on_small' => false,
     ), $atts, 'page_feature' );
 


### PR DESCRIPTION
We had the default type of hero image defined in the wrong place and as such it was always overriding the page custom fields.
solves #283 