### PR TITLE
Factoring out analytics tracking codes for easier child theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Extra widgets can be added to the Footer.  These will appear on the bottom of th
 
 - This theme uses [RespondJS](https://github.com/scottjehl/Respond) to make media queries work on IE 6-8. If you use a CDN to host CSS files, make sure they do not use `@import` and that they also allow cross domain requests to files.
 
+- This theme includes the current **Google Tag Manager** and **Lavidge AdWords** tracking that should be on all ASU sites. For implementing custom tracking codes create a child theme and override the `analytics-body-tracking-code.php` file.
+
 ## Developers Corner
 
 You will need [Bower](http://bower.io/) and Grunt installed

--- a/analytics-body-tracking-codes.php
+++ b/analytics-body-tracking-codes.php
@@ -1,0 +1,52 @@
+<?php
+/* Analytics Tracking Codes that go in the top of the <body> element
+ *
+ * Coding standards complains about inlineing a script tag, which we're choosing to ignore here to
+ * keep these tracking codes together.
+ */
+// @codingStandardsIgnoreStart
+?>
+
+
+  <!-- Google Tag Manager ASU Universal-->
+  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KDWN8Z"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','SI_dataLayer','GTM-KDWN8Z');</script>
+  <!-- End Google Tag Manager ASU Universal -->
+
+  <!-- Lavidge AdWords Tracking -->
+  <script>
+    var versaTag = {};
+    versaTag.id = "5381";
+    versaTag.sync = 0;
+    versaTag.dispType = "js";
+    versaTag.ptcl = "HTTPS";
+    versaTag.bsUrl = "bs.serving-sys.com/BurstingPipe";
+    versaTag.activityParams = {
+    "OrderID":"","Session":"","Value":"","productid":"","productinfo":"","Quantity":""
+    };
+    versaTag.retargetParams = {};
+    versaTag.dynamicRetargetParams = {};
+    versaTag.conditionalParams = {};
+  </script>
+  <script id="ebOneTagUrlId" src="https://secure-ds.serving-sys.com/SemiCachedScripts/ebOneTag.js"></script>
+  <noscript>
+    <iframe src="https://bs.serving-sys.com/BurstingPipe?
+      cn=ot&amp;
+      onetagid=5381&amp;
+      ns=1&amp;
+      activityValues=$$Value=[Value]&amp;OrderID=[OrderID]&amp;Session=[Session]&amp;ProductID=[ProductID]&amp;ProductInfo=[ProductInfo]&amp;Quantity=[Quantity]$$&amp;
+      retargetingValues=$$$$&amp;
+      dynamicRetargetingValues=$$$$&amp;
+      acp=$$$$&amp;"
+      style="display:none;width:0px;height:0px"></iframe>
+  </noscript>
+  <!-- End Lavidge AdWords Tracking -->
+
+
+<?php
+// @codingStandardsIgnoreEnd

--- a/header.php
+++ b/header.php
@@ -176,43 +176,7 @@ HTML;
 <body <?php body_class(); ?>>
   <a href="#skippy" class="sr-only">Skip to Content</a>
 
-  <!-- Google Tag Manager ASU Universal-->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KDWN8Z"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','SI_dataLayer','GTM-KDWN8Z');</script>
-  <!-- End Google Tag Manager ASU Universal -->
-  <!-- Lavidge AdWords Tracking -->
-  <script>
-    var versaTag = {};
-    versaTag.id = "5381";
-    versaTag.sync = 0;
-    versaTag.dispType = "js";
-    versaTag.ptcl = "HTTPS";
-    versaTag.bsUrl = "bs.serving-sys.com/BurstingPipe";
-    versaTag.activityParams = {
-    "OrderID":"","Session":"","Value":"","productid":"","productinfo":"","Quantity":""
-    };
-    versaTag.retargetParams = {};
-    versaTag.dynamicRetargetParams = {};
-    versaTag.conditionalParams = {};
-  </script>
-  <script id="ebOneTagUrlId" src="https://secure-ds.serving-sys.com/SemiCachedScripts/ebOneTag.js"></script>
-  <noscript>
-    <iframe src="https://bs.serving-sys.com/BurstingPipe?
-      cn=ot&amp;
-      onetagid=5381&amp;
-      ns=1&amp;
-      activityValues=$$Value=[Value]&amp;OrderID=[OrderID]&amp;Session=[Session]&amp;ProductID=[ProductID]&amp;ProductInfo=[ProductInfo]&amp;Quantity=[Quantity]$$&amp;
-      retargetingValues=$$$$&amp;
-      dynamicRetargetingValues=$$$$&amp;
-      acp=$$$$&amp;"
-      style="display:none;width:0px;height:0px"></iframe>
-  </noscript>
-  <!-- End Lavidge AdWords Tracking -->
+  <?php include 'analytics-body-tracking.php'; ?>
 
   <div id="page-wrapper">
     <div id="page">

--- a/header.php
+++ b/header.php
@@ -176,7 +176,7 @@ HTML;
 <body <?php body_class(); ?>>
   <a href="#skippy" class="sr-only">Skip to Content</a>
 
-  <?php include 'analytics-body-tracking.php'; ?>
+  <?php include 'analytics-body-tracking-codes.php'; ?>
 
   <div id="page-wrapper">
     <div id="page">


### PR DESCRIPTION
Now child themes can just override the `analytics-body-tracking-codes.php` file rather than the `header.php`.

FYI @bryanbarker, I figured we might as well do this now since we're thinking about it. 