### PR TITLE
Allowing Child themes to override files that get included via php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -426,7 +426,7 @@ function prevent_iframes() {
 add_action( 'wp_head', 'prevent_iframes' );
 
 
-if ( ! function_exists ( 'include_theme_file' ) ) {
+if ( ! function_exists( 'include_theme_file' ) ) {
   /** Include a file in this theme or child theme if its present in the child theme. We can't just
    * always call include with get_stylesheet_directory()."filename" because that will require that the
    * child theme always define that file. Instead we want the child theme to optionally override files
@@ -434,7 +434,7 @@ if ( ! function_exists ( 'include_theme_file' ) ) {
    */
   function include_theme_file( $filename ) {
     // error_log( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename );
-    if ( file_exists ( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename ) ) {
+    if ( file_exists( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename ) ) {
       include get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename;
 
     } else {

--- a/functions.php
+++ b/functions.php
@@ -435,10 +435,10 @@ if ( ! function_exists( 'include_theme_file' ) ) {
   function include_theme_file( $filename ) {
     // error_log( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename );
     if ( file_exists( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename ) ) {
-      include get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename;
+      include( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename );
 
     } else {
-      include ( $filename );
+      include( $filename );
       // include will throw warnings if the file isn't found
     }
 

--- a/functions.php
+++ b/functions.php
@@ -424,3 +424,23 @@ function prevent_iframes() {
   }
 }
 add_action( 'wp_head', 'prevent_iframes' );
+
+
+if ( ! function_exists ( 'include_theme_file' ) ) {
+  /** Include a file in this theme or child theme if its present in the child theme. We can't just
+   * always call include with get_stylesheet_directory()."filename" because that will require that the
+   * child theme always define that file. Instead we want the child theme to optionally override files
+   * that they want to change.
+   */
+  function include_theme_file( $filename ) {
+    // error_log( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename );
+    if ( file_exists ( get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename ) ) {
+      include get_stylesheet_directory() . DIRECTORY_SEPARATOR . $filename;
+
+    } else {
+      include ( $filename );
+      // include will throw warnings if the file isn't found
+    }
+
+  }
+}

--- a/header.php
+++ b/header.php
@@ -184,18 +184,18 @@ HTML;
     if ( $asu_analytics <> 'disable' ) {
       // Include the 'analytics-body-tracking-codes.php' file to run script for running analytics. If not, the
       // file containing the script isn't included and it does not run.
-      require_once( 'analytics-body-tracking-codes.php' );
-    } // else: Action required when ASU Analytics is disabled.
+      include_theme_file( 'analytics-body-tracking-codes.php' );
+    } // else: ASU Analytics is disabled.
   }
   else { // If customize option is not present, enable tracking by default.
-      require_once( 'analytics-body-tracking-codes.php' );
+      include_theme_file( 'analytics-body-tracking-codes.php' );
   }
   ?>
 
   <div id="page-wrapper">
     <div id="page">
       <div id="asu_header">
-        <?php include 'header-asu.php'; ?>
+        <?php include_theme_file( 'header-asu.php' ); ?>
         <div id="site-name-desktop" class="section site-name-desktop">
           <div class="container">
             <div class="site-title" id="asu_school_name"

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@
  * @package asu-wordpress-web-standards
  */
 
-include 'helpers/mime-types-helper.php';
+include_template_file( 'helpers/mime-types-helper.php' );
 
 get_header();
 

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@
  * @package asu-wordpress-web-standards
  */
 
-include_template_file( 'helpers/mime-types-helper.php' );
+include_theme_file( 'helpers/mime-types-helper.php' );
 
 get_header();
 

--- a/page.php
+++ b/page.php
@@ -12,7 +12,7 @@
  * @package asu-wordpress-web-standards-theme
  */
 
-include 'helpers/mime-types-helper.php';
+include_template_file( 'helpers/mime-types-helper.php' );
 
 get_header();
 

--- a/page.php
+++ b/page.php
@@ -12,7 +12,7 @@
  * @package asu-wordpress-web-standards-theme
  */
 
-include_template_file( 'helpers/mime-types-helper.php' );
+include_theme_file( 'helpers/mime-types-helper.php' );
 
 get_header();
 


### PR DESCRIPTION
A child theme should be able to override any file in the parent just by defining it. This was not the case for `header-asu.php` and `analytics-body-tracking-codes.php`, they were directly included in php which didn't allow for a child theme to override them.  I've introduced a new function `include_theme_file( $filename )` to try and include a file in the child theme first if present, otherwise include it in the parent theme. 