### PR TITLE
Update anti-clickjack (cross-frame/iframe exploits)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -413,19 +413,35 @@ function prevent_iframes() {
   if ( ! is_customize_preview() ) {
     // prevent pages from being iframed
     ?>
+      <style id="antiClickjack">body{display:none !important;}</style>
       <script type="text/javascript">
-        if ( top.frames.length != 0 ) {
-            if ( window.location.href.replace )
-               top.location.replace( self.location.href );
-            else
-               top.location.href = self.document.href;
-        }
-     </script>
+       if (self === top) {
+           var antiClickjack = document.getElementById("antiClickjack");
+           antiClickjack.parentNode.removeChild(antiClickjack);
+       } else {
+           top.location = self.location;
+       }
+      </script>
     <?php
   }
 }
 add_action( 'wp_head', 'prevent_iframes' );
 
+/**
+ * Prevent iframes by adding response header
+ * This is a recommended primary layer of protection, with the anti-clickjack script
+ * used as a reliable failback for legacy browsers.
+ *
+ * TODO: Review in future to replace deprecated X-Frame-Options header with
+ * frame-ancestors directive (https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet)
+ */
+function add_x_frame_options_header() {
+  if ( ! is_customize_preview() ) {
+    // prevent pages from being iframed
+    header( 'X-Frame-Options: DENY' );
+  }
+}
+add_action( 'send_headers', 'add_header_xua' );
 
 if ( ! function_exists( 'include_theme_file' ) ) {
   /** Include a file in this theme or child theme if its present in the child theme. We can't just

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/gios-asu/ASU-Web-Standards-Wordpress-Theme
 Author: <a href="https://sustainability.asu.edu/?utm_source=wordpress&utm_medium=theme&utm_campaign=ASU-Wordpress-Web-Standards-Theme">The Julie Ann Wrigley Global Institute of Sustainability</a>
 Author URI: http://sustainability.asu.edu
 Description: ASU Web Standards compliant Wordpress Theme, for questions and updates please use the github repository: <a href="https://github.com/gios-asu/ASU-Wordpress-Web-Standards-Theme?utm_source=wordpress&utm_medium=theme&utm_campaign=ASU-Wordpress-Web-Standards-Theme">github.com/gios-asu/ASU-Wordpress-Web-Standards-Theme</a>.
-Version: 2.2.2
+Version: 2.2.3
 License: MIT
 License URI: https://github.com/gios-asu/ASU-Web-Standards-Wordpress-Theme/blob/master/LICENSE
 Text Domain: asu-wordpress-web-standards


### PR DESCRIPTION
The implemented anti-clickjack script to prevent iframes of our websites, is vulnerable to defeat. [OWASP recommends](https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet) alternative script logic, plus the addition of X-Frame-Option headers denying iframes.