### PR TITLE
Fix sidebar dropdowns

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -24,44 +24,39 @@ get_header(); ?>
       <main id="main" class="site-main space-top-md" role="main">
         <div class="container">
           <div class="row">
-            <?php
-            
-            // Set up our default layout: 8 columns for content, 4 for the sidebar
-            $content_class = 'col-sm-8';
-            $sidebar_class = 'col-sm-4 hidden-xs';
-            
-            /**
-             * Here we check to see if our sidebar is NOT active, or if it has no
-             * widgets to render. In that case, we don't need a sidebar - so we give
-             * the content the full 12 columns.
-             * 
-             * https://codex.wordpress.org/Function_Reference/is_active_sidebar
-             */
-            if( ! is_active_sidebar( 'sidebar-1' ) ) {
-                $content_class = 'col-sm-12';
-                $sidebar_class = 'hidden-xs';
-                }              
-            ?>
-            
-            <div class="<?php echo esc_attr( $content_class ); ?>">
-              
-                <?php
-            
-                while ( have_posts() ) {
-                    the_post();
-                    get_template_part( 'content', get_post_format() );
+          <?php
+          //Set up our default layout: 8 columns for content, 4 for the sidebar
+          $content_class = 'col-sm-8';
+          $sidebar_class = 'col-sm-4 hidden-xs';
 
-                    // If comments are open or we have at least one comment, load up the comment template
-                    if ( comments_open() || '0' != get_comments_number() ) {
-                        comments_template();
-                        }
-                     } // end of the loop.
-                ?>
-              
+          /**
+          * Here we check to see if our sidebar is NOT active, or if it has no
+          * widgets to render. In that case, we don't need a sidebar - so we give
+          * the content the full 12 columns.
+          *
+          * https://codex.wordpress.org/Function_Reference/is_active_sidebar
+          */
+          if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+            $content_class = 'col-sm-12';
+            $sidebar_class = 'hidden-xs';
+          }
+          ?>
+
+          <div class="<?php echo esc_attr( $content_class ); ?>">
+          <?php
+          while ( have_posts() ) {
+            the_post();
+            get_template_part( 'content', get_post_format() );
+
+            // If comments are open or we have at least one comment, load up the comment template
+            if ( comments_open() || '0' != get_comments_number() ) {
+              comments_template();
+            }
+          }
+          ?>
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
-            <h2><?php echo( wp_kses_post( "Yo! MTV Sidebars" ) );?></h2>
-              <div id="secondary" class="widget-area row" role="complementary">              
+              <div id="secondary" class="widget-area row" role="complementary">
                 <?php get_sidebar(); ?>
               </div>
             </div>

--- a/archive.php
+++ b/archive.php
@@ -25,36 +25,44 @@ get_header(); ?>
         <div class="container">
           <div class="row">
             <?php
-              ob_start();
-                get_sidebar();
-                $sidebar_content = ob_get_contents();
-              ob_end_clean();
-
-              // Default widths for having a sidebar
-              $content_class = 'col-sm-8';
-              $sidebar_class = 'col-sm-4 hidden-xs';
-            if ( false == trim( $sidebar_content ) ) {
-              // if the sidebar has no content then the page should take it all up
-              $content_class = 'col-sm-12';
-              $sidebar_class = 'hidden-xs';
-            }
+            
+            // Set up our default layout: 8 columns for content, 4 for the sidebar
+            $content_class = 'col-sm-8';
+            $sidebar_class = 'col-sm-4 hidden-xs';
+            
+            /**
+             * Here we check to see if our sidebar is NOT active, or if it has no
+             * widgets to render. In that case, we don't need a sidebar - so we give
+             * the content the full 12 columns.
+             * 
+             * https://codex.wordpress.org/Function_Reference/is_active_sidebar
+             */
+            if( ! is_active_sidebar( 'sidebar-1' ) ) {
+                $content_class = 'col-sm-12';
+                $sidebar_class = 'hidden-xs';
+                }              
             ?>
+            
             <div class="<?php echo esc_attr( $content_class ); ?>">
-              <?php
-              while ( have_posts() ) {
-                the_post();
-                get_template_part( 'content', get_post_format() );
+              
+                <?php
+            
+                while ( have_posts() ) {
+                    the_post();
+                    get_template_part( 'content', get_post_format() );
 
-                // If comments are open or we have at least one comment, load up the comment template
-                if ( comments_open() || '0' != get_comments_number() ) {
-                  comments_template();
-                }
-              } // end of the loop.
-              ?>
+                    // If comments are open or we have at least one comment, load up the comment template
+                    if ( comments_open() || '0' != get_comments_number() ) {
+                        comments_template();
+                        }
+                     } // end of the loop.
+                ?>
+              
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
-              <div id="secondary" class="widget-area row" role="complementary">
-                <?php echo $sidebar_content; ?>
+            <h2><?php echo( wp_kses_post( "Yo! MTV Sidebars" ) );?></h2>
+              <div id="secondary" class="widget-area row" role="complementary">              
+                <?php get_sidebar(); ?>
               </div>
             </div>
           </div>

--- a/archive.php
+++ b/archive.php
@@ -54,7 +54,7 @@ get_header(); ?>
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">
-                <?php echo wp_kses( $sidebar_content, wp_kses_allowed_html( 'post' ) ); ?>
+                <?php echo $sidebar_content; ?>
               </div>
             </div>
           </div>

--- a/category.php
+++ b/category.php
@@ -83,7 +83,7 @@ get_header(); ?>
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">
-                <?php echo wp_kses( $sidebar_content, wp_kses_allowed_html( 'post' ) ); ?>
+                <?php echo $sidebar_content; ?>
                </div>
             </div>
           </div>

--- a/category.php
+++ b/category.php
@@ -52,18 +52,18 @@ get_header(); ?>
               // Set up our default layout: 8 columns for content, 4 for the sidebar
             $content_class = 'col-sm-8';
             $sidebar_class = 'col-sm-4 hidden-xs';
-            
+
             /**
              * Here we check to see if our sidebar is NOT active, or if it has no
              * widgets to render. In that case, we don't need a sidebar - so we give
              * the content the full 12 columns.
-             * 
+             *
              * https://codex.wordpress.org/Function_Reference/is_active_sidebar
              */
-            if( ! is_active_sidebar( 'sidebar-1' ) ) {
+            if ( ! is_active_sidebar( 'sidebar-1' ) ) {
                 $content_class = 'col-sm-12';
                 $sidebar_class = 'hidden-xs';
-                }   
+            }
             ?>
             <div class="<?php echo esc_attr( $content_class ); ?>">
               <?php

--- a/category.php
+++ b/category.php
@@ -49,19 +49,21 @@ get_header(); ?>
 
           <div class="row">
             <?php
-              ob_start();
-                get_sidebar();
-                $sidebar_content = ob_get_contents();
-              ob_end_clean();
-
-              // Default widths for having a sidebar
-              $content_class = 'col-sm-8';
-              $sidebar_class = 'col-sm-4 hidden-xs';
-            if ( false == trim( $sidebar_content ) ) {
-              // if the sidebar has no content then the page should take it all up
-              $content_class = 'col-sm-12';
-              $sidebar_class = 'hidden-xs';
-            }
+              // Set up our default layout: 8 columns for content, 4 for the sidebar
+            $content_class = 'col-sm-8';
+            $sidebar_class = 'col-sm-4 hidden-xs';
+            
+            /**
+             * Here we check to see if our sidebar is NOT active, or if it has no
+             * widgets to render. In that case, we don't need a sidebar - so we give
+             * the content the full 12 columns.
+             * 
+             * https://codex.wordpress.org/Function_Reference/is_active_sidebar
+             */
+            if( ! is_active_sidebar( 'sidebar-1' ) ) {
+                $content_class = 'col-sm-12';
+                $sidebar_class = 'hidden-xs';
+                }   
             ?>
             <div class="<?php echo esc_attr( $content_class ); ?>">
               <?php
@@ -83,7 +85,7 @@ get_header(); ?>
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">
-                <?php echo $sidebar_content; ?>
+                <?php get_sidebar(); ?>
                </div>
             </div>
           </div>

--- a/index.php
+++ b/index.php
@@ -29,7 +29,26 @@ $custom_fields = get_post_custom();
       <main id="main" class="site-main space-top-md" role="main">
         <div class="container">
           <div class="row">
-            <div class="col-sm-8">
+
+            <?php
+            // Set up our default layout: 8 columns for content, 4 for the sidebar
+            $content_class = 'col-sm-8';
+            $sidebar_class = 'col-sm-4 hidden-xs';
+
+            /**
+             * Here we check to see if our sidebar is NOT active, or if it has no
+             * widgets to render. In that case, we don't need a sidebar - so we give
+             * the content the full 12 columns.
+             *
+             * https://codex.wordpress.org/Function_Reference/is_active_sidebar
+             */
+            if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+                $content_class = 'col-sm-12';
+                $sidebar_class = 'hidden-xs';
+            }
+            ?>
+
+            <div class="<?php echo esc_attr( $content_class ); ?>">
               <?php
               while ( have_posts() ) {
                 the_post();
@@ -42,7 +61,7 @@ $custom_fields = get_post_custom();
               } // end of the loop.
               ?>
             </div>
-            <div class="col-sm-4 hidden-xs">
+            <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">
                 <?php get_sidebar(); ?>
               <div>

--- a/single.php
+++ b/single.php
@@ -56,7 +56,7 @@ $custom_fields = get_post_custom();
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">
-                <?php echo wp_kses( $sidebar_content, wp_kses_allowed_html( 'post' ) ); ?>
+                <?php echo $sidebar_content; ?>
               </div>
             </div>
 

--- a/single.php
+++ b/single.php
@@ -19,44 +19,43 @@ $custom_fields = get_post_custom();
         <div class="container">
           <div class="row">
             <?php
-              ob_start();
-                get_sidebar();
-                $sidebar_content = ob_get_contents();
-              ob_end_clean();
-
-              // Default widths for having a sidebar
-              $content_class = 'col-sm-8';
-              $sidebar_class = 'col-sm-4 hidden-xs';
-            if ( false == trim( $sidebar_content ) ) {
-              // if the sidebar has no content then the page should take it all up
-              $content_class = 'col-sm-12';
-              $sidebar_class = 'hidden-xs';
-            }
+            
+            // Set up our default layout: 8 columns for content, 4 for the sidebar
+            $content_class = 'col-sm-8';
+            $sidebar_class = 'col-sm-4 hidden-xs';
+            
+            /**
+             * Here we check to see if our sidebar is NOT active, or if it has no
+             * widgets to render. In that case, we don't need a sidebar - so we give
+             * the content the full 12 columns.
+             * 
+             * https://codex.wordpress.org/Function_Reference/is_active_sidebar
+             */
+            if( ! is_active_sidebar( 'sidebar-1' ) ) {
+                $content_class = 'col-sm-12';
+                $sidebar_class = 'hidden-xs';
+                }              
             ?>
-
+            
             <div class="<?php echo esc_attr( $content_class ); ?>">
-
-              <header class="entry-header">
-                <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-                <div class="entry-meta">
-                  <?php asu_webstandards_posted_on(); ?>
-                </div><!-- .entry-meta -->
-              </header><!-- .entry-header -->
-              <div class="single">
+              
                 <?php
+            
                 while ( have_posts() ) {
-                  the_post();
+                    the_post();
+                    get_template_part( 'content', get_post_format() );
 
-                  get_template_part( 'content', 'single' );
-
-                  asu_webstandards_post_nav();
-                }
+                    // If comments are open or we have at least one comment, load up the comment template
+                    if ( comments_open() || '0' != get_comments_number() ) {
+                        comments_template();
+                        }
+                     } // end of the loop.
                 ?>
-              </div>
+              
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">
-                <?php echo $sidebar_content; ?>
+                <?php get_sidebar(); ?>
               </div>
             </div>
 

--- a/single.php
+++ b/single.php
@@ -37,18 +37,22 @@ $custom_fields = get_post_custom();
           ?>
 
           <div class="<?php echo esc_attr( $content_class ); ?>">
+            <header class="entry-header">
+              <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+              <div class="entry-meta">
+                <?php asu_webstandards_posted_on(); ?>
+              </div><!-- .entry-meta -->
+            </header><!-- .entry-header -->
 
-          <?php
-          while ( have_posts() ) {
-            the_post();
-            get_template_part( 'content', get_post_format() );
-
-            //If comments are open or we have at least one comment, load up the comment template
-            if ( comments_open() || '0' != get_comments_number() ) {
-              comments_template();
-            }
-          }
-          ?>
+            <div class="single">
+              <?php
+              while ( have_posts() ) {
+                the_post();
+                get_template_part( 'content', 'single' );
+                asu_webstandards_post_nav();
+              }
+              ?>
+            </div>
 
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">

--- a/single.php
+++ b/single.php
@@ -18,40 +18,38 @@ $custom_fields = get_post_custom();
       <main id="main" class="site-main space-top-md">
         <div class="container">
           <div class="row">
-            <?php
-            
-            // Set up our default layout: 8 columns for content, 4 for the sidebar
-            $content_class = 'col-sm-8';
-            $sidebar_class = 'col-sm-4 hidden-xs';
-            
-            /**
-             * Here we check to see if our sidebar is NOT active, or if it has no
-             * widgets to render. In that case, we don't need a sidebar - so we give
-             * the content the full 12 columns.
-             * 
-             * https://codex.wordpress.org/Function_Reference/is_active_sidebar
-             */
-            if( ! is_active_sidebar( 'sidebar-1' ) ) {
-                $content_class = 'col-sm-12';
-                $sidebar_class = 'hidden-xs';
-                }              
-            ?>
-            
-            <div class="<?php echo esc_attr( $content_class ); ?>">
-              
-                <?php
-            
-                while ( have_posts() ) {
-                    the_post();
-                    get_template_part( 'content', get_post_format() );
+          <?php
+          // Set up our default layout: 8 columns for content, 4 for the sidebar
+          $content_class = 'col-sm-8';
+          $sidebar_class = 'col-sm-4 hidden-xs';
 
-                    // If comments are open or we have at least one comment, load up the comment template
-                    if ( comments_open() || '0' != get_comments_number() ) {
-                        comments_template();
-                        }
-                     } // end of the loop.
-                ?>
-              
+          /**
+          * Here we check to see if our sidebar is NOT active, or if it has no
+          * widgets to render. In that case, we don't need a sidebar - so we give
+          * the content the full 12 columns.
+          *
+          * https://codex.wordpress.org/Function_Reference/is_active_sidebar
+          */
+          if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+            $content_class = 'col-sm-12';
+            $sidebar_class = 'hidden-xs';
+          }
+          ?>
+
+          <div class="<?php echo esc_attr( $content_class ); ?>">
+
+          <?php
+          while ( have_posts() ) {
+            the_post();
+            get_template_part( 'content', get_post_format() );
+
+            //If comments are open or we have at least one comment, load up the comment template
+            if ( comments_open() || '0' != get_comments_number() ) {
+              comments_template();
+            }
+          }
+          ?>
+
             </div>
             <div class="<?php echo esc_attr( $sidebar_class ); ?>">
               <div id="secondary" class="widget-area row" role="complementary">


### PR DESCRIPTION
## Summary
Changed the way we were dealing with conditionally displaying the sidebar on three, specific, archive pages:

* archive.php
* category.php
* single.php

There was some code on these three pages that would modify the basic page layout if the sidebar was empty - allowing the archived posts to fill the available space. The method in place was to use output buffering to capture the sidebar, test to see if it was an empty string, and modify the classes applied to certain `<div>` elements based on that test.

If the sidebar was **not** empty, we echoed it out after cleaning it up with the `wp_kses_post()` method. Unfortunately, passing the sidebar through that sanitization method removed HTML tags that are required for some built-in WordPress widgets.

I changed the logic to use the `is_active_sidebar()` method which will return a value of **false** if the sidebar is not active on the page, **or** if it has no registered widgets (essentially the same as it being empty). Using this built-in Wordpress method, and then outputting the sidebar via the standard `get_sidebar()` method should accomplish the same goal without breaking existing sidebar widgets.

## Notes

* Is there a situation where we expect to display posts (either **archived** or **by category**) without a sidebar? The more I dug around through the files, the less I thought that this situation would ever really happen. It applies only to displaying actual Wordpress **posts** - and only when filtering by category or date, or viewing a single post. It would not apply to our static pages - and would not seem to apply to our events or news pages, as they override the default sidebar anyway.

* The Bootstrap class we apply to the sidebar when it's empty is `hidden-xs`, which, for the record, is **only** going to hide the sidebar div on extra small screens. Of course, when Wordpress finds no sidebar widgets to render, it doesn't output anything regardless of screen size. Still, it's worth nothing if odd things show up in the future.




