### PR TITLE
Accessibility (a11y) updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ For Web Standards documentation, checkout the [Enterprise Brand and Marketing Gu
 ## System Requirements
 This theme requires PHP **5.4.0+** and up will work up to 7.0. It has also been tested with WordPress v4.*
 
+## UPVERSION NOTES
+
+Upversion these files:
+
+* functions.php
+* style.css
+
+
 ## Installation
 
 [Download the latest version of the theme](https://github.com/gios-asu/ASU-Web-Standards-Wordpress-Theme/releases/latest).

--- a/functions.php
+++ b/functions.php
@@ -152,12 +152,12 @@ function asu_webstandards_scripts() {
   // Upversion this number when you include a new version of the web standards
   // This is not necessarily the version of the web standards you are using,
   // but rather a local version number of the web standards assets for WordPress
-  $asu_web_standards_version = '1.0.4';
+  $asu_web_standards_version = '1.0.5';
 
   // dependency versions
   $jquery_version = '2.2.4';
   $bootstrap_version = '3.3.7';
-  $asu_header_version = '4.0.1';
+  $asu_header_version = '4.0.2';
 
   // Wordpress provides jquery, but we enqueue our own mainly so we include it in the footer and control the version.
   wp_deregister_script( 'jquery' );

--- a/header-asu.php
+++ b/header-asu.php
@@ -4,6 +4,7 @@
     <div class="region region-header">
       <div id="block-asu-brand-asu-brand-header" class="block block-asu-brand">
         <div class="content">
+          <div id="asu-report-accessiblity" class="accessibility-hide"><a href="https://www.asu.edu/accessibility/" class="sr-only sr-only-focusable" tabindex="0">Report an accessibility problem</a></div>
           <!-- START /asuthemes/4.0-rsp-up.0/headers/default_white.shtml -->
           <div id="asu_hdr" class=" asu_hdr_white chrome">
             <div id="asu_mobile_menu" class="toggle_off">

--- a/header-asu.php
+++ b/header-asu.php
@@ -7,6 +7,27 @@
           <div id="asu-report-accessiblity" class="accessibility-hide"><a href="https://www.asu.edu/accessibility/" class="sr-only sr-only-focusable" tabindex="0">Report an accessibility problem</a></div>
           <!-- START /asuthemes/4.0-rsp-up.0/headers/default_white.shtml -->
           <div id="asu_hdr" class=" asu_hdr_white chrome">
+            <div id="asu_mobile_hdr">
+              <div id="asu_logo">
+                <?php
+                $html = apply_filters( 'asu_logo', '' );
+
+                if ( ! empty( $html ) ) {
+                  echo wp_kses_post( $html );
+                } else {
+                ?>
+                <a target="_top" href="http://www.asu.edu/" title="Arizona State University" id="asu-logo-in-header" tabindex="0">
+                  <img alt="Arizona State University" title="Arizona State University" src="//www.asu.edu/asuthemes/4.6/assets/full_logo.png"  height="36" width="200">
+                </a>
+                <?php
+                }
+                ?>
+              </div>
+              <!-- /#asu_logo  -->
+              <img src="//www.asu.edu/asuthemes/4.6/assets/full_logo.png" height="32" id="asu_print_logo" alt="ASU Logo" tabindex="0"/>
+              <div id="asu_mobile_button" class="asushow"><a href="javascript:toggleASU();" data-target=".navbar-collapse" data-toggle="collapse">Menu</a></div>
+            </div>
+            <!-- /#asu_mobile_header  -->
             <div id="asu_mobile_menu" class="toggle_off">
               <div id="asu_nav_wrapper">
                 <h2 class="hidden">Sign In / Sign Out</h2>
@@ -99,27 +120,6 @@
               <!-- /#asu_search -->
             </div>
             <!-- /#asu_mobile_menu -->
-            <div id="asu_mobile_hdr">
-              <div id="asu_logo">
-                <?php
-                $html = apply_filters( 'asu_logo', '' );
-
-                if ( ! empty( $html ) ) {
-                  echo wp_kses_post( $html );
-                } else {
-                ?>
-                <a target="_top" href="http://www.asu.edu/" title="Arizona State University" id="asu-logo-in-header" tabindex="0">
-                  <img alt="Arizona State University" title="Arizona State University" src="//www.asu.edu/asuthemes/4.6/assets/full_logo.png"  height="36" width="200">
-                </a>
-                <?php
-                }
-                ?>
-              </div>
-              <!-- /#asu_logo  -->
-              <img src="//www.asu.edu/asuthemes/4.6/assets/full_logo.png" height="32" id="asu_print_logo" alt="ASU Logo" />
-              <div id="asu_mobile_button" class="asushow"><a href="javascript:toggleASU();" data-target=".navbar-collapse" data-toggle="collapse">Menu</a></div>
-            </div>
-            <!-- /#asu_mobile_header  -->
           </div>
           <!-- /#asu_hdr -->
           <div style="clear:both;"></div>

--- a/header-asu.php
+++ b/header-asu.php
@@ -108,7 +108,7 @@
                   echo wp_kses_post( $html );
                 } else {
                 ?>
-                <a target="_top" href="http://www.asu.edu/" title="Arizona State University" id="asu-logo-in-header">
+                <a target="_top" href="http://www.asu.edu/" title="Arizona State University" id="asu-logo-in-header" tabindex="0">
                   <img alt="Arizona State University" title="Arizona State University" src="//www.asu.edu/asuthemes/4.6/assets/full_logo.png"  height="36" width="200">
                 </a>
                 <?php

--- a/header.php
+++ b/header.php
@@ -181,7 +181,7 @@ HTML;
 </head>
 
 <body <?php body_class(); ?>>
-  <a href="#skippy" class="sr-only">Skip to Content</a>
+  <a href="#skippy" class="sr-only sr-only-focusable" tabindex="0">Skip to Content</a>
 
   <?php
   // Do we have asu_analytics?


### PR DESCRIPTION
* Added missing screen reader focusable class to Skip to Content link
* Added new "Report on Accessibility" link to top of page (and made tabbable and focusable.)
* Re-ordered ASU header components so ASU logo is first in source order for a logical tabbing sequence.